### PR TITLE
feat: self-contained research worker for Cloudflare deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@
 
 ## Cloudflare Research Dashboard
 
-This repository now also contains an experimental dashboard interface that runs on Cloudflare
-Pages/Workers. The dashboard exposes the existing research agents through a secure Worker API and
-renders a Radix UI powered Next.js front‑end where users can search U.S./Canadian equities and
-download generated reports.
+This repository now also contains an experimental dashboard interface that runs entirely on
+Cloudflare Pages and Workers. The Worker performs the equity research using OpenAI and stores
+results in a KV namespace, while the Radix UI powered Next.js front‑end lets users search
+U.S./Canadian equities and download generated reports.
 
 - Dynamic ticker search with auto‑complete.
 - Streaming progress bar that describes each step of the research.
@@ -60,14 +60,15 @@ download generated reports.
 - Reports are stored in a Cloudflare KV namespace and indexed for all users.
 
 - Front‑end code lives in [`dashboard`](dashboard) and is built with the Next.js App Router.
-- A minimal Worker that proxies requests to the Python research engine is located in
-  [`worker`](worker).
+- The Worker implementation lives in [`worker`](worker) and runs the research directly on the
+  edge, storing completed reports in KV.
 
 To deploy on Cloudflare Pages:
 
 1. Create a KV namespace and bind it as `REPORTS` in [`worker/wrangler.toml`](worker/wrangler.toml).
-2. Deploy the worker with `npm --prefix worker run deploy` and note its public URL.
-3. In the Pages project settings, set `WORKER_URL` to that Worker URL and build the dashboard with `npm --prefix dashboard run build`.
+2. Set your OpenAI API key as `OPENAI_API_KEY` in the same file or via the Cloudflare dashboard.
+3. Deploy the worker with `npm --prefix worker run deploy` and note its public URL.
+4. In the Pages project settings, set `WORKER_URL` to that Worker URL and build the dashboard with `npm --prefix dashboard run build`.
 
 The trading manager from the original framework is intentionally omitted so the system focuses on
 research generation only.

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -3,7 +3,7 @@ main = "src/index.ts"
 compatibility_date = "2024-05-01"
 
 [vars]
-RESEARCH_API_URL = "https://example.com/api"
+OPENAI_API_KEY = "your-openai-key"
 
 [[kv_namespaces]]
 binding = "REPORTS"


### PR DESCRIPTION
## Summary
- run research directly in Cloudflare Worker using OpenAI and Yahoo Finance data
- stream JSON status updates and final report text to dashboard
- teach dashboard to parse streaming updates and display progress
- document worker configuration for OpenAI and KV

## Testing
- `npm --prefix worker test`
- `npm --prefix dashboard test`


------
https://chatgpt.com/codex/tasks/task_e_688d12decd788328bc0fb83823b66bd7